### PR TITLE
Fix year button spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,12 +18,12 @@
 
     <div class="calendar">
         <div class="calendar-header">
-            <span class="month-picker" id="month-picker">February</span>
+            <span class="month-picker" id="month-picker"></span>
             <div class="year-picker">
                 <span class="year-change" id="prev-year">
                     <pre><</pre>
                 </span>
-                <span id="year">2021</span>
+                <span id="year"></span>
                 <span class="year-change" id="next-year">
                     <pre>></pre>
                 </span>

--- a/style.css
+++ b/style.css
@@ -219,7 +219,7 @@ body {
   border-radius: 50%;
   display: grid;
   place-items: center;
-  margin: 0 10px;
+  margin-top:10px;
   cursor: pointer;
 }
 


### PR DESCRIPTION
#3 Pull Request: Fix Year-Change Button Spacing and Remove Unnecessary Code

#5 also fixed 

## Description
This pull request addresses an issue where the year-change buttons in the calendar display were not equally spaced. The left button had more space than the right one, which affected the visual balance and alignment of the user interface. Additionally, I've removed unnecessary code related to the year "2021" and the month "February."

## Changes Made
I made the following code changes to achieve this:

- Adjusted the CSS for the year-change buttons to ensure equal spacing on both sides.
- Previously, the left button had more space than the right one, causing an imbalance.
- Removed unnecessary code related to the year "2021" and the month "February."
- The changes improve the visual aesthetics of the calendar, making it more consistent, user-friendly, and cleaner.

## Before and After Screenshots
### Before:
![Before](https://github.com/devas22/calendar/assets/109026120/c1022593-a351-4bbc-bd5c-802d671c80a2)

### After Code Changes:
![After](https://github.com/devas22/calendar/assets/109026120/c70468c7-c79f-4957-af46-52498f7d5475)

## Code Changes
I've made the following code adjustments in this pull request:
![Code Changes](https://github.com/devas22/calendar/assets/109026120/43f47656-4a94-4286-885c-574e239552ab)
<img width="808" alt="Screenshot 2023-10-07 185907" src="https://github.com/devas22/calendar/assets/109026120/6b3911b1-c615-4b23-a763-22c49e8fffb6">


This fix enhances the overall user experience, ensures a consistent and visually pleasing calendar display, and removes unnecessary clutter from the codebase.

Please review and merge this pull request. Thank you!
